### PR TITLE
Added ISSUE_TEMPLATES.

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,19 @@
+---
+name: "👾 Bug Report"
+about: Report a bug you found on beta.dmod.gg.
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- Provide a clear and concise description of the bug you're reporting -->
+
+## Steps to reproduce
+
+<!-- Provide a list of steps for us to experience the same behaviour -->
+
+## Screenshots
+
+<!-- Provide any screenshots you can, or delete this section entirely -->

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "👾 Bug Report"
 about: Report a bug you found on beta.dmod.gg.
-title: ""
+title: "Bug:"
 labels: bug
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "💡 Feature Request"
 about: Request a feature to be added to beta.dmod.gg.
-title: ""
+title: "Feature request:"
 labels: enhancement
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,11 @@
+---
+name: "💡 Feature Request"
+about: Request a feature to be added to beta.dmod.gg.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Description
+
+<!-- Provide a clear and concise description of the feature you're suggesting  -->

--- a/.github/ISSUE_TEMPLATE/---visual-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---visual-bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "👀 Visual Bug Report"
 about: Report a visual bug you found on beta.dmod.gg.
-title: ""
+title: "Visual Bug:"
 labels: bug, visual
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/---visual-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---visual-bug-report.md
@@ -1,0 +1,19 @@
+---
+name: "👀 Visual Bug Report"
+about: Report a visual bug you found on beta.dmod.gg.
+title: ""
+labels: bug, visual
+assignees: ""
+---
+
+## Description
+
+<!-- Provide a clear and concise description of the visual bug you're reporting -->
+
+## Steps to reproduce
+
+<!-- Provide a list of steps for us to experience the same behaviour -->
+
+## Screenshots
+
+<!-- Provide any screenshots you can, or delete this section entirely -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Support & Questions
+    url: https://dmod.gg/discord
+    about: Need any support or have any questions? Join our Discord Server!


### PR DESCRIPTION
To create more concise and straight two-the-point issues, I added ISSUE_TEMPLATES. This allows users to make an issue specifically for a feature request, bug report, or visual bug report.  Once you have gone through the initial page of distinguishing what type of issue you would like to create, a standard-issue page should appear. In that, there will be preset headings such as, "Steps to reproduce", "Description" and "Screenshots" with corresponding comments to help users make an issue. Additionally, the issue should automatically append set labels. 

Labels:

👾 Bug Report = bug
👀 Visual Bug Report = bug & visual
💡 Feature Request = enhancement 


This is what it will look like:

<details>
  <summary>🚀 Once you click "New issue" on standard issues page.</summary> 
  <img src="https://us.tixte.net/uploads/cdn.anaxes.xyz/ksfqu9nnl9a.png"/>
</details>

<details>
  <summary>✍ Defaul writiting "new issue" page.</summary> 
  <img src="https://us.tixte.net/uploads/cdn.anaxes.xyz/ksfqujc839a.png"/>
</details>
